### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Unit tests
 
 on: [push, workflow_dispatch]
 
+permissions:
+    contents: read
+
 jobs:
     test:
         runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/KhiopsML/khiops-visualization/security/code-scanning/5](https://github.com/KhiopsML/khiops-visualization/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to check out the repository and run tests, it requires minimal permissions. The `contents: read` permission is sufficient for accessing the repository's code. No write permissions are necessary.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
