### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,10 @@ name: Publish to NPM
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/KhiopsML/khiops-visualization/security/code-scanning/7](https://github.com/KhiopsML/khiops-visualization/security/code-scanning/7)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are appropriate:
- `contents: read` for reading repository contents.
- `packages: write` for publishing to npm.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`publish`) to limit permissions to that job only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
