### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,7 @@
 name: End-to-end tests
 on: [push, workflow_dispatch]
+permissions:
+  contents: read
 
 jobs:
   cypress-run:


### PR DESCRIPTION
Potential fix for [https://github.com/KhiopsML/khiops-visualization/security/code-scanning/6](https://github.com/KhiopsML/khiops-visualization/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow (`checkout`, `build`, `upload-artifact`), the `contents: read` permission is sufficient. This permission allows the workflow to read repository contents without granting write access.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs, or it can be added specifically to the `cypress-run` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
